### PR TITLE
Fix(Tag), Fix(useFocusScroll): Поправлено влияние SSR и исправление className в Tag

### DIFF
--- a/packages/toolkit/src/hooks/index.ts
+++ b/packages/toolkit/src/hooks/index.ts
@@ -9,3 +9,4 @@ export {default as useVisibilityToggler} from './useVisibilityToggler';
 export {default as useWatcher} from './useCombinedRef';
 export {default as useAutoFocus} from './useAutoFocus';
 export {default as useFocusScroll} from './useFocusScroll';
+export {default as useSafeLayoutEffect} from './useSafeLayoutEffect';

--- a/packages/toolkit/src/hooks/useFocusScroll.ts
+++ b/packages/toolkit/src/hooks/useFocusScroll.ts
@@ -1,5 +1,6 @@
-import {useLayoutEffect, useCallback} from 'react';
+import {useCallback} from 'react';
 import {smoothScroll} from '../utils';
+import useSafeLayoutEffect from './useSafeLayoutEffect';
 
 export default function useFocusScroll<
   R extends React.RefObject<HTMLInputElement | null>
@@ -13,7 +14,7 @@ export default function useFocusScroll<
     }, 500);
   }, [inputRef]);
 
-  useLayoutEffect(() => {
+  useSafeLayoutEffect(() => {
     const {current: element} = inputRef;
     if (enabled && element) {
       element.addEventListener('focus', scrollIntoView);

--- a/packages/toolkit/src/hooks/useSafeLayoutEffect.ts
+++ b/packages/toolkit/src/hooks/useSafeLayoutEffect.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import canUseDom from '../utils/canUseDom';
+
+/**
+ * Данный хук позволяет безопасно вызывать `useLayoutEffect` на клиенте
+ * с учетом возможности вызова этого хука на сервере.
+ *
+ * Сейчас React кидает предупреждение, когда пытаешься использовать useLayoutEffect на сервере.
+ * Чтобы обойти это ограничение мы используем useEffect на сервере и useLayoutEffect в браузере.
+ *
+ * @see https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
+ */
+const useSafeLayoutEffect = canUseDom()
+  ? React.useLayoutEffect
+  : React.useEffect;
+
+export default useSafeLayoutEffect;

--- a/packages/ui/src/Tag/index.tsx
+++ b/packages/ui/src/Tag/index.tsx
@@ -19,7 +19,7 @@ export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Tag: React.FC<TagProps> = (props) => {
-  const {size = 'm', children, current, leading, trailing, active, disabled, onClick, ...rest} = props;
+  const {size = 'm', children, current, leading, trailing, active, disabled, onClick, className, ...rest} = props;
 
   return (
     <div
@@ -28,7 +28,8 @@ const Tag: React.FC<TagProps> = (props) => {
         styles[`size-${size}`],
         current && styles['current'],
         active && styles['active'],
-        disabled && styles['disabled']
+        disabled && styles['disabled'],
+        className,
       )}
       aria-disabled={disabled}
       role = "button"


### PR DESCRIPTION

1. Добавил новый хук для безопасного использоваться `useLayoutEffect`;
2. Исправил баг с `className` в компоненте тэг.