### PR TITLE
fix(ui): [SEMANTICS-4834] DropdownArea flex css

### DIFF
--- a/packages/ui/src/Dropdown/components/DropdownPortal/DropdownPortal.module.scss
+++ b/packages/ui/src/Dropdown/components/DropdownPortal/DropdownPortal.module.scss
@@ -59,7 +59,7 @@
 .dropdown-area {
   box-shadow: var(--ui-box-shadow);
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   flex-direction: column;
   background: #fff;
   border-radius: var(--ui-border-radius-l);


### PR DESCRIPTION
Из-за `justify-content:center` в дропдауне визарда на вебе со временем варианты времени отображались не все, а только с 11 утра. Надо `flex-start`
![image](https://github.com/user-attachments/assets/61e19bc1-0723-45c4-8506-81ad20d3fd8f)
