### PR TITLE
Feat: [SEMANTICS-4919] Datepicker invalid prop & css

### DIFF
--- a/packages/ui/src/Datepicker/Datepicker.module.scss
+++ b/packages/ui/src/Datepicker/Datepicker.module.scss
@@ -27,6 +27,11 @@
   padding-bottom: 30px;
 }
 
+.invalid {
+  box-shadow: 0 0 0 1px var(--ui-color-warning);
+  border-radius: 10px;
+}
+
 @keyframes slide-up {
   0% {
     transform: translate3d(0, 10px, 0);

--- a/packages/ui/src/Datepicker/Datepicker.stories.tsx
+++ b/packages/ui/src/Datepicker/Datepicker.stories.tsx
@@ -19,11 +19,15 @@ BaseStory.storyName = 'Datepicker';
 BaseStory.args = {
   value: shiftDate(new Date('Tue Jul 06 2021 01:01:01 GMT+0300'), 1),
   minDate: new Date('Tue Jul 04 2021 01:01:01 GMT+0300'),
+  invalid: false,
 };
 
 export const WithCustomLabelStory = Template.bind({});
 WithCustomLabelStory.storyName = 'Datepicker with custom label';
 WithCustomLabelStory.args = {
   value: new Date(),
-  inputLabelTransformerList: [(date: Date) => new Date().toDateString() === date.toDateString() ? 'Сегодня' : null],
+  inputLabelTransformerList: [
+    (date: Date) =>
+      new Date().toDateString() === date.toDateString() ? 'Сегодня' : null,
+  ],
 };

--- a/packages/ui/src/Datepicker/index.tsx
+++ b/packages/ui/src/Datepicker/index.tsx
@@ -26,6 +26,7 @@ export type DatepickerProps = Omit<
    * Применяется справо налево и применяется первый, который подходит.
    */
   inputLabelTransformerList?: ((date: Date) => string)[];
+  invalid?: boolean;
 };
 
 const Datepicker: React.FC<React.PropsWithChildren<DatepickerProps>> = ({
@@ -37,6 +38,7 @@ const Datepicker: React.FC<React.PropsWithChildren<DatepickerProps>> = ({
   calendarClassName,
   onChange: _onChange,
   inputLabelTransformerList = [],
+  invalid = false,
   ...calendarProps
 }) => {
   const isMobile = useCurrentScreen('mobile', false);
@@ -73,7 +75,7 @@ const Datepicker: React.FC<React.PropsWithChildren<DatepickerProps>> = ({
   return (
     <Dropdown
       data-shmid={shmid}
-      className={className}
+      className={classnames(className, invalid && styles['invalid'])}
       closeRefHandler={closeDropdownRef}
       onChange={setDatepickerOpen}
     >


### PR DESCRIPTION
- В рамках задачи по выносу плеера из варпа [SEMANTICS-4919](https://profiru.atlassian.net/browse/SEMANTICS-4919) - вынос компонента DateTime
- Добавлен в DatePicker пропс `invalid?: boolean` + стили (обводка)

[SEMANTICS-4919]: https://profiru.atlassian.net/browse/SEMANTICS-4919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ