### PR TITLE
Feat: [SEMANTICS-4919] дубль 2: Datepicker invalid prop запихнуть глубже

### DIFF
--- a/packages/ui/src/Datepicker/Datepicker.module.scss
+++ b/packages/ui/src/Datepicker/Datepicker.module.scss
@@ -27,11 +27,6 @@
   padding-bottom: 30px;
 }
 
-.invalid {
-  box-shadow: 0 0 0 1px var(--ui-color-warning);
-  border-radius: 10px;
-}
-
 @keyframes slide-up {
   0% {
     transform: translate3d(0, 10px, 0);

--- a/packages/ui/src/Datepicker/Datepicker.stories.tsx
+++ b/packages/ui/src/Datepicker/Datepicker.stories.tsx
@@ -19,7 +19,6 @@ BaseStory.storyName = 'Datepicker';
 BaseStory.args = {
   value: shiftDate(new Date('Tue Jul 06 2021 01:01:01 GMT+0300'), 1),
   minDate: new Date('Tue Jul 04 2021 01:01:01 GMT+0300'),
-  invalid: false,
 };
 
 export const WithCustomLabelStory = Template.bind({});

--- a/packages/ui/src/Datepicker/index.tsx
+++ b/packages/ui/src/Datepicker/index.tsx
@@ -38,7 +38,7 @@ const Datepicker: React.FC<React.PropsWithChildren<DatepickerProps>> = ({
   calendarClassName,
   onChange: _onChange,
   inputLabelTransformerList = [],
-  invalid = false,
+  invalid,
   ...calendarProps
 }) => {
   const isMobile = useCurrentScreen('mobile', false);
@@ -75,9 +75,10 @@ const Datepicker: React.FC<React.PropsWithChildren<DatepickerProps>> = ({
   return (
     <Dropdown
       data-shmid={shmid}
-      className={classnames(className, invalid && styles['invalid'])}
+      className={className}
       closeRefHandler={closeDropdownRef}
       onChange={setDatepickerOpen}
+      invalid={invalid}
     >
       <Dropdown.Toggler
         as={Input}

--- a/packages/ui/src/Dropdown/Dropdown.module.css
+++ b/packages/ui/src/Dropdown/Dropdown.module.css
@@ -1,3 +1,7 @@
 .relative {
   position: relative;
 }
+.invalid {
+  box-shadow: 0 0 0 1px var(--ui-color-warning);
+  border-radius: 10px;
+}

--- a/packages/ui/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.stories.tsx
@@ -237,6 +237,9 @@ const Template: Story = (args) => {
 };
 
 export const Default = Template.bind({});
+Default.args = {
+  invalid: false,
+};
 
 export const Without_animation = Template.bind({});
 Without_animation.args = {

--- a/packages/ui/src/Dropdown/index.tsx
+++ b/packages/ui/src/Dropdown/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useMemo,
-  useRef,
-  useCallback,
-  MutableRefObject,
-} from 'react';
+import React, {useMemo, useRef, useCallback, MutableRefObject} from 'react';
 import cx from 'classnames';
 
 import DropdownToggler from './components/DropdownToggler';
@@ -24,9 +19,11 @@ export type DropdownProps = {
   trigger?: 'click' | 'hover';
   defaultOpened?: boolean;
   styles?: React.CSSProperties;
+  invalid?: boolean;
 };
 
-interface DropdownComponent extends React.FC<React.PropsWithChildren<DropdownProps>> {
+interface DropdownComponent
+  extends React.FC<React.PropsWithChildren<DropdownProps>> {
   Toggler: typeof DropdownToggler;
   Portal: typeof DropdownPortal;
   Item: typeof DropdownItem;
@@ -40,6 +37,7 @@ const Dropdown: DropdownComponent = ({
   closeRefHandler,
   defaultOpened,
   trigger = 'click',
+  invalid = false,
   ...props
 }) => {
   const dropdownRef = useRef<HTMLDivElement | null>(null);
@@ -72,7 +70,11 @@ const Dropdown: DropdownComponent = ({
   return (
     <DropdownContext.Provider value={context}>
       <div
-        className={cx(className, styles['relative'])}
+        className={cx(
+          className,
+          styles['relative'],
+          invalid && styles['invalid'],
+        )}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         ref={dropdownRef}


### PR DESCRIPTION
Для сторибука достаточно было связать `invalid:boolean` со стилем на уровне верхнего компонента Datepicker, но по факту надо цеплять класс в дочернем Dropdown. Надеюсь, что на этот раз сработает)