### PR TITLE
fix: [FP-1978] add compatibility for react 19

### DIFF
--- a/packages/ui/src/BottomSheet/index.tsx
+++ b/packages/ui/src/BottomSheet/index.tsx
@@ -58,6 +58,10 @@ const BottomSheet: ForwardRefExoticComponent<
   ) => {
     const bodyEl = useRef(null);
 
+    // фикс для совместимости с 19 реактом. Если указан nodeRef, react-transition-group использует его, а не findDOMNode
+    const transitionRef = useRef(null);
+    const transitionRef1 = useRef(null);
+
     // Отключаем промотку body
     useEffect(() => {
       if (!inline) {
@@ -85,6 +89,7 @@ const BottomSheet: ForwardRefExoticComponent<
       <>
         {!inline && (
           <CSSTransition
+            nodeRef={transitionRef}
             unmountOnExit
             mountOnEnter
             in={visible}
@@ -101,6 +106,7 @@ const BottomSheet: ForwardRefExoticComponent<
         )}
 
         <CSSTransition
+          nodeRef={transitionRef1}
           unmountOnExit
           mountOnEnter
           in={visible}

--- a/packages/ui/src/Modal/index.tsx
+++ b/packages/ui/src/Modal/index.tsx
@@ -93,6 +93,11 @@ const Modal = React.forwardRef(
     ref,
   ) => {
     const bodyRef = React.useRef(null);
+
+    // фикс для совместимости с 19 реактом. Если указан nodeRef, react-transition-group использует его, а не findDOMNode
+    const transitionRef = React.useRef(null);
+    const transitionRef1 = React.useRef(null);
+
     const [modalRef, setModalRef] = useCombinedRef(ref);
     const modalContentRef = useRef<HTMLDivElement>(null);
 
@@ -154,6 +159,7 @@ const Modal = React.forwardRef(
         value={{handleClose: handleCloseClick, handleBack: handleBackClick}}
       >
         <CSSTransition
+          nodeRef={transitionRef}
           key="overlay"
           unmountOnExit
           in={visible}
@@ -170,6 +176,7 @@ const Modal = React.forwardRef(
         </CSSTransition>
 
         <CSSTransition
+          nodeRef={transitionRef1}
           key="content"
           unmountOnExit
           in={visible}


### PR DESCRIPTION
указал рефки для react-transition-group компонентов, чтоб они не ходили в findDOMNode