### PR TITLE
chore(release): publish

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.55.11](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-icons@0.55.10...@eruditorgroup/profi-icons@0.55.11) (2025-08-19)
+
+**Note:** Version bump only for package @eruditorgroup/profi-icons
+
+
+
+
+
 ## [0.55.10](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-icons@0.55.9...@eruditorgroup/profi-icons@0.55.10) (2025-08-15)
 
 **Note:** Version bump only for package @eruditorgroup/profi-icons

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-icons",
-  "version": "0.55.10",
+  "version": "0.55.11",
   "description": "Common icon set for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",
@@ -29,7 +29,7 @@
     "/src"
   ],
   "dependencies": {
-    "@eruditorgroup/profi-toolkit": "^0.62.7"
+    "@eruditorgroup/profi-toolkit": "^0.62.8"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.62.8](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-toolkit@0.62.7...@eruditorgroup/profi-toolkit@0.62.8) (2025-08-19)
+
+
+
+## 0.33.69 (2025-08-19)
+
+
+### Bug Fixes
+
+* [PRFR-4434] fix modal scroll on iOS Safari ([#667](https://github.com/eruditorgroup/profi-design-system/issues/667)) ([7551749](https://github.com/eruditorgroup/profi-design-system/commit/7551749d63f77c4e33bb73d2b5237f468b5a9e29))
+
+
+
+
+
 ## [0.62.7](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-toolkit@0.62.6...@eruditorgroup/profi-toolkit@0.62.7) (2025-08-15)
 
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-toolkit",
-  "version": "0.62.7",
+  "version": "0.62.8",
   "description": "Toolkit for React for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.90.2](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-ui@0.90.1...@eruditorgroup/profi-ui@0.90.2) (2025-08-19)
+
+
+
+## 0.33.69 (2025-08-19)
+
+
+### Bug Fixes
+
+* [PRFR-4434] fix modal scroll on iOS Safari ([#667](https://github.com/eruditorgroup/profi-design-system/issues/667)) ([7551749](https://github.com/eruditorgroup/profi-design-system/commit/7551749d63f77c4e33bb73d2b5237f468b5a9e29))
+
+
+
+
+
 ## [0.90.1](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-ui@0.90.0...@eruditorgroup/profi-ui@0.90.1) (2025-08-15)
 
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-ui",
-  "version": "0.90.1",
+  "version": "0.90.2",
   "description": "Essential cross-platform UI components for React for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",
@@ -29,8 +29,8 @@
     "/src"
   ],
   "dependencies": {
-    "@eruditorgroup/profi-icons": "^0.55.10",
-    "@eruditorgroup/profi-toolkit": "^0.62.7",
+    "@eruditorgroup/profi-icons": "^0.55.11",
+    "@eruditorgroup/profi-toolkit": "^0.62.8",
     "body-scroll-lock": "^3.1.5",
     "classnames": "^2.2.6",
     "react-autosuggest": "^10.1.0",


### PR DESCRIPTION
 - @eruditorgroup/profi-icons@0.55.11
 - @eruditorgroup/profi-toolkit@0.62.8
 - @eruditorgroup/profi-ui@0.90.2