### PR TITLE
chore(release): publish

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.68](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-icons@1.0.0-alpha.67...@eruditorgroup/profi-icons@1.0.0-alpha.68) (2025-08-19)
+
+**Note:** Version bump only for package @eruditorgroup/profi-icons
+
+
+
+
+
 # [1.0.0-alpha.67](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-icons@1.0.0-alpha.66...@eruditorgroup/profi-icons@1.0.0-alpha.67) (2025-08-15)
 
 **Note:** Version bump only for package @eruditorgroup/profi-icons

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-icons",
-  "version": "1.0.0-alpha.67",
+  "version": "1.0.0-alpha.68",
   "description": "Common icon set for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",
@@ -28,7 +28,7 @@
     "/src"
   ],
   "dependencies": {
-    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.67"
+    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.68"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.68](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-toolkit@1.0.0-alpha.67...@eruditorgroup/profi-toolkit@1.0.0-alpha.68) (2025-08-19)
+
+
+
+# 1.0.0-alpha.68 (2025-08-19)
+
+
+### Bug Fixes
+
+* [PRFR-4434] fix modal scroll on iOS Safari ([#667](https://github.com/eruditorgroup/profi-design-system/issues/667)) ([783e9b4](https://github.com/eruditorgroup/profi-design-system/commit/783e9b4ac5b61d96f5ca910498b28ae88616ca3e))
+
+
+
+
+
 # [1.0.0-alpha.67](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-toolkit@1.0.0-alpha.66...@eruditorgroup/profi-toolkit@1.0.0-alpha.67) (2025-08-15)
 
 **Note:** Version bump only for package @eruditorgroup/profi-toolkit

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-toolkit",
-  "version": "1.0.0-alpha.67",
+  "version": "1.0.0-alpha.68",
   "description": "Toolkit for React for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.68](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-ui@1.0.0-alpha.67...@eruditorgroup/profi-ui@1.0.0-alpha.68) (2025-08-19)
+
+
+
+# 1.0.0-alpha.68 (2025-08-19)
+
+
+### Bug Fixes
+
+* [PRFR-4434] fix modal scroll on iOS Safari ([#667](https://github.com/eruditorgroup/profi-design-system/issues/667)) ([783e9b4](https://github.com/eruditorgroup/profi-design-system/commit/783e9b4ac5b61d96f5ca910498b28ae88616ca3e))
+
+
+
+
+
 # [1.0.0-alpha.67](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-ui@1.0.0-alpha.66...@eruditorgroup/profi-ui@1.0.0-alpha.67) (2025-08-15)
 
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-ui",
-  "version": "1.0.0-alpha.67",
+  "version": "1.0.0-alpha.68",
   "description": "Essential cross-platform UI components for React for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",
@@ -28,8 +28,8 @@
     "/src"
   ],
   "dependencies": {
-    "@eruditorgroup/profi-icons": "^1.0.0-alpha.67",
-    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.67",
+    "@eruditorgroup/profi-icons": "^1.0.0-alpha.68",
+    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.68",
     "body-scroll-lock": "^3.1.5",
     "classnames": "^2.2.6",
     "react-autosuggest": "^10.1.0",


### PR DESCRIPTION
 - @eruditorgroup/profi-icons@1.0.0-alpha.68
 - @eruditorgroup/profi-toolkit@1.0.0-alpha.68
 - @eruditorgroup/profi-ui@1.0.0-alpha.68