### PR TITLE
chore(release): publish

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.76](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-icons@1.0.0-alpha.75...@eruditorgroup/profi-icons@1.0.0-alpha.76) (2025-12-11)
+
+**Note:** Version bump only for package @eruditorgroup/profi-icons
+
+
+
+
+
 # [1.0.0-alpha.75](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-icons@1.0.0-alpha.74...@eruditorgroup/profi-icons@1.0.0-alpha.75) (2025-11-17)
 
 **Note:** Version bump only for package @eruditorgroup/profi-icons

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-icons",
-  "version": "1.0.0-alpha.75",
+  "version": "1.0.0-alpha.76",
   "description": "Common icon set for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",
@@ -28,7 +28,7 @@
     "/src"
   ],
   "dependencies": {
-    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.75"
+    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.76"
   },
   "peerDependencies": {
     "react": "^16.14.0",

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.76](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-toolkit@1.0.0-alpha.75...@eruditorgroup/profi-toolkit@1.0.0-alpha.76) (2025-12-11)
+
+**Note:** Version bump only for package @eruditorgroup/profi-toolkit
+
+
+
+
+
 # [1.0.0-alpha.75](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-toolkit@1.0.0-alpha.74...@eruditorgroup/profi-toolkit@1.0.0-alpha.75) (2025-11-17)
 
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-toolkit",
-  "version": "1.0.0-alpha.75",
+  "version": "1.0.0-alpha.76",
   "description": "Toolkit for React for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.76](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-ui@1.0.0-alpha.75...@eruditorgroup/profi-ui@1.0.0-alpha.76) (2025-12-11)
+
+
+
+# 1.0.0-alpha.76 (2025-12-11)
+
+
+### Bug Fixes
+
+* [FM-5858] check element in body scroll lock inside BottomSheet ([#695](https://github.com/eruditorgroup/profi-design-system/issues/695)) ([dbd5bec](https://github.com/eruditorgroup/profi-design-system/commit/dbd5bec7949c11072407b73294663aa9faa40921))
+
+
+
+
+
 # [1.0.0-alpha.75](https://github.com/eruditorgroup/profi-design-system/compare/@eruditorgroup/profi-ui@1.0.0-alpha.74...@eruditorgroup/profi-ui@1.0.0-alpha.75) (2025-11-17)
 
 **Note:** Version bump only for package @eruditorgroup/profi-ui

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruditorgroup/profi-ui",
-  "version": "1.0.0-alpha.75",
+  "version": "1.0.0-alpha.76",
   "description": "Essential cross-platform UI components for React for Eruditor Group",
   "author": "eruditorgroup",
   "license": "ISC",
@@ -28,8 +28,8 @@
     "/src"
   ],
   "dependencies": {
-    "@eruditorgroup/profi-icons": "^1.0.0-alpha.75",
-    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.75",
+    "@eruditorgroup/profi-icons": "^1.0.0-alpha.76",
+    "@eruditorgroup/profi-toolkit": "^1.0.0-alpha.76",
     "body-scroll-lock": "^3.1.5",
     "classnames": "^2.2.6",
     "react-autosuggest": "^10.1.0",


### PR DESCRIPTION
 - @eruditorgroup/profi-icons@1.0.0-alpha.76
 - @eruditorgroup/profi-toolkit@1.0.0-alpha.76
 - @eruditorgroup/profi-ui@1.0.0-alpha.76